### PR TITLE
Rename repository to Awesome Symfony

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Awesome Symfony 2 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
-A list of awesome [Symfony 2](http://symfony.com) bundles, utilities and resources.
+# Awesome Symfony [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+A list of awesome [Symfony](http://symfony.com) bundles, utilities and resources.
 
 Table of contents:
 


### PR DESCRIPTION
Symfony 3.0 will be released soon. It might be good idea to also rename this repository to just awesome-symfony instead of awesome-symfony2. Thank you for considering also this idea :)